### PR TITLE
NAS-131305 / 24.10.1 / cache parse_dmi() (by yocalebo)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.11'
     - name: Install pytest
       run: |
         python -m pip install --upgrade pip

--- a/ixhardware/dmi.py
+++ b/ixhardware/dmi.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from datetime import date, datetime
+from functools import cache
 import logging
 import subprocess
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +11,7 @@ __all__ = ["DMIInfo", "DMIParser", "parse_dmi"]
 
 @dataclass
 class DMIInfo:
-    bios_release_date: Optional[date] = None
+    bios_release_date: date | None = None
     ecc_memory: bool = False
     baseboard_manufacturer: str = ""
     baseboard_product_name: str = ""
@@ -28,7 +28,7 @@ class DMIParser:
     def parse(self, output: str) -> DMIInfo:
         return self._parse_dmi(output.splitlines())
 
-    def _parse_dmi(self, lines: [str]) -> DMIInfo:
+    def _parse_dmi(self, lines: list[str]) -> DMIInfo:
         info = DMIInfo()
 
         _type = None
@@ -89,11 +89,20 @@ class DMIParser:
         try:
             return datetime.strptime(string, formatter).date()
         except Exception as e:
-            logger.warning(f"Failed to format BIOS release date to datetime object: {e!r}")
+            logger.warning(
+                f"Failed to format BIOS release date to datetime object: {e!r}"
+            )
 
 
+@cache
 def parse_dmi() -> DMIInfo:
     return DMIParser().parse(
-        subprocess.run(DMIParser.command, check=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-                       encoding="utf-8", errors="ignore").stdout
+        subprocess.run(
+            DMIParser.command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            encoding="utf-8",
+            errors="ignore",
+        ).stdout
     )


### PR DESCRIPTION
This information is static so cache it to prevent fork+exec'ing every time this is called. Necessary for changes introduced in https://github.com/truenas/middleware/pull/14657.

Original PR: https://github.com/truenas/ixhardware/pull/3
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131305