### PR TITLE
NAS-134012 / 25.10 / freeze DMIInfo

### DIFF
--- a/ixhardware/chassis.py
+++ b/ixhardware/chassis.py
@@ -1,4 +1,4 @@
-from .dmi import DMIInfo
+from .dmi import DMIInfo, parse_dmi
 
 __all__ = ["PLATFORM_PREFIXES", "TRUENAS_UNKNOWN", "get_chassis_hardware"]
 
@@ -19,7 +19,10 @@ PLATFORM_PREFIXES = (
 TRUENAS_UNKNOWN = "TRUENAS-UNKNOWN"
 
 
-def get_chassis_hardware(dmi: DMIInfo):
+def get_chassis_hardware(dmi: DMIInfo | None = None) -> str:
+    if dmi is None:
+        dmi = parse_dmi()
+
     if dmi.system_product_name.startswith(PLATFORM_PREFIXES):
         return dmi.system_product_name
 


### PR DESCRIPTION
Since `parse_dmi` is cached, we need to make `DMIInfo` dataclass frozen since caching a mutable object leads to very hard to troubleshoot issues.

Also, instead of forcing `get_chassis_hardware` to accept an argument of type `DMIInfo` allow it be NoneType and populate it accordingly. This helps to make it more ergonomic for downstream consumers.